### PR TITLE
Relative paths work properly now for server copies on local system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Edit HTML files visually in real-time.
 
 ## 📋 Changelog
 
-### 0.1.13 (2026-06-14)
+### 0.1.14 (2026-06-14)
 - **Fixed**: Root-relative paths (`/scripts/...`) now resolve from workspace root instead of HTML file's directory
 - **Fixed**: Relative paths with leading `/` (e.g., `/scripts.js`) are now properly handled in WebView
 - These changes allow simulating a local server where `/scripts/` references work from any HTML file in the workspace

--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
-> [!NOTE]
-> This project was developed with the assistance of AI (OpenCode with Nemotron-3-Ultra).
-
 # Web Visual Editor [![Installs](https://img.shields.io/visual-studio-marketplace/i/urin.vscode-web-visual-editor?cacheSeconds=86400)](https://marketplace.visualstudio.com/items?itemName=Urin.vscode-web-visual-editor) [![Stars](https://img.shields.io/github/stars/urin/vscode-web-visual-editor?style=flat)](https://api.star-history.com/svg?repos=urin/vscode-web-visual-editor&type=Timeline)
 
 Edit HTML files visually in real-time.
-
-## 📋 Changelog
-
-### 0.1.14 (2026-06-14)
-- **Fixed**: Root-relative paths (`/scripts/...`) now resolve from workspace root instead of HTML file's directory
-- **Fixed**: Relative paths with leading `/` (e.g., `/scripts.js`) are now properly handled in WebView
-- These changes allow simulating a local server where `/scripts/` references work from any HTML file in the workspace
 
 <img src="https://raw.githubusercontent.com/urin/vscode-web-visual-editor/main/docs/demo.webp" alt="Demo">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
+> [!NOTE]
+> This project was developed with the assistance of AI (OpenCode with Nemotron-3-Ultra).
+
 # Web Visual Editor [![Installs](https://img.shields.io/visual-studio-marketplace/i/urin.vscode-web-visual-editor?cacheSeconds=86400)](https://marketplace.visualstudio.com/items?itemName=Urin.vscode-web-visual-editor) [![Stars](https://img.shields.io/github/stars/urin/vscode-web-visual-editor?style=flat)](https://api.star-history.com/svg?repos=urin/vscode-web-visual-editor&type=Timeline)
 
 Edit HTML files visually in real-time.
+
+## 📋 Changelog
+
+### 0.1.13 (2026-06-14)
+- **Fixed**: Root-relative paths (`/scripts/...`) now resolve from workspace root instead of HTML file's directory
+- **Fixed**: Relative paths with leading `/` (e.g., `/scripts.js`) are now properly handled in WebView
+- These changes allow simulating a local server where `/scripts/` references work from any HTML file in the workspace
 
 <img src="https://raw.githubusercontent.com/urin/vscode-web-visual-editor/main/docs/demo.webp" alt="Demo">
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   ],
   "icon": "images/icon-logo.png",
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.99.0",
+    "node": ">=25.0.0"
   },
   "publisher": "Urin",
   "author": "Urin",
@@ -46,7 +47,7 @@
     "@types/he": "^1.2.3",
     "@types/jsdom": "^21.1.7",
     "@types/mocha": "^10.0.10",
-    "@types/node": "22.x",
+    "@types/node": "25.x",
     "@types/vscode": "^1.99.1",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "@typescript-eslint/parser": "^8.30.1",
@@ -55,7 +56,7 @@
     "esbuild": "^0.25.2",
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.9.3"
+    "typescript": "^5.8.3"
   },
   "main": "./dist/extension.js",
   "activationEvents": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "esbuild": "^0.25.2",
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.3"
   },
   "main": "./dist/extension.js",
   "activationEvents": [

--- a/src/visualEditor.ts
+++ b/src/visualEditor.ts
@@ -305,19 +305,17 @@ export class VisualEditorProvider implements vscode.CustomTextEditorProvider {
     document.body.querySelectorAll('input[type=file]').forEach(el => el.setAttribute('disabled', ''));
     // - Replace URIs (mainly for CSS files) to be handled in sandbox of WebView
     // - Save resource path to update WebView when it changes
+    const curdir = path.dirname(code.uri.fsPath);
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(code.uri);
-    const workspaceRoot = workspaceFolder?.uri.fsPath ?? path.dirname(code.uri.fsPath);
+    const root = workspaceFolder?.uri.fsPath ?? curdir;
     ['href', 'src'].forEach(attr => {
       document.querySelectorAll(`[${attr}]`).forEach(el => {
         if (el.tagName === 'A') { return; }
         const uri = el.getAttribute(attr)!;
-        if (!this.isRelativePath(uri)) { return; }
-        this.addToResources(code, uri);
-        const basePath = uri.startsWith('/') ? workspaceRoot : path.dirname(code.uri.fsPath);
-        const resolvedPath = path.join(basePath, uri.replace(/^\//, ''));
-        const safeUri = webview.asWebviewUri(
-          vscode.Uri.file(resolvedPath)
-        ).toString();
+        if (!this.isLocalResource(uri)) { return; }
+        const resolvedPath = path.join(uri.startsWith('/') ? root : curdir, uri.replace(/^\//, ''));
+        this.addToResources(code, resolvedPath);
+        const safeUri = webview.asWebviewUri(vscode.Uri.file(resolvedPath)).toString();
         el.setAttribute(attr, safeUri);
       });
     });
@@ -381,8 +379,7 @@ export class VisualEditorProvider implements vscode.CustomTextEditorProvider {
     });
   }
 
-  private addToResources(code: vscode.TextDocument, uri: string) {
-    const filepath = path.join(path.dirname(code.uri.fsPath), uri);
+  private addToResources(code: vscode.TextDocument, filepath: string) {
     if (this.resources.has(filepath)) {
       this.resources.get(filepath)?.add(code);
     } else {
@@ -390,13 +387,14 @@ export class VisualEditorProvider implements vscode.CustomTextEditorProvider {
     }
   }
 
-  private isRelativePath(path: string) {
-    try {
-      new URL(path);
-      return false;
-    } catch (e) {
-      return true; // Treat all non-URLs as relative (including /path)
-    }
+  private isLocalResource(path: string) {
+    // Treat a path as a local resource if it resolves to the same origin as a dummy
+    // base URL. This excludes absolute URLs (`https://...`), protocol-relative URLs
+    // (`//cdn.example.com/...`), and special schemes (`mailto:`, `data:`, etc., which
+    // resolve to an opaque origin), while including normal relative paths and
+    // root-relative paths (e.g., `/scripts/main.js`).
+    const base = 'https://wve-local-resource.invalid/';
+    return new URL(path, base).origin === new URL(base).origin;
   }
 
   private shortName(el: Element) {

--- a/src/visualEditor.ts
+++ b/src/visualEditor.ts
@@ -305,14 +305,18 @@ export class VisualEditorProvider implements vscode.CustomTextEditorProvider {
     document.body.querySelectorAll('input[type=file]').forEach(el => el.setAttribute('disabled', ''));
     // - Replace URIs (mainly for CSS files) to be handled in sandbox of WebView
     // - Save resource path to update WebView when it changes
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(code.uri);
+    const workspaceRoot = workspaceFolder?.uri.fsPath ?? path.dirname(code.uri.fsPath);
     ['href', 'src'].forEach(attr => {
       document.querySelectorAll(`[${attr}]`).forEach(el => {
         if (el.tagName === 'A') { return; }
         const uri = el.getAttribute(attr)!;
         if (!this.isRelativePath(uri)) { return; }
         this.addToResources(code, uri);
+        const basePath = uri.startsWith('/') ? workspaceRoot : path.dirname(code.uri.fsPath);
+        const resolvedPath = path.join(basePath, uri.replace(/^\//, ''));
         const safeUri = webview.asWebviewUri(
-          vscode.Uri.file(path.join(path.dirname(code.uri.fsPath), uri))
+          vscode.Uri.file(resolvedPath)
         ).toString();
         el.setAttribute(attr, safeUri);
       });
@@ -391,7 +395,7 @@ export class VisualEditorProvider implements vscode.CustomTextEditorProvider {
       new URL(path);
       return false;
     } catch (e) {
-      return !path.startsWith('/');
+      return true; // Treat all non-URLs as relative (including /path)
     }
   }
 


### PR DESCRIPTION
Note: It was all done by AI. I have verified the changes from my end and seem logical to me but it also required updating typscript to a newer version. Feel free to accept or reject this pull but it helped me immensely.

## 📋 Changelog

### 0.1.14 (2026-06-14)
- **Fixed**: Root-relative paths (`/scripts/...`) now resolve from workspace root instead of HTML file's directory
- **Fixed**: Relative paths with leading `/` (e.g., `/scripts.js`) are now properly handled in WebView
- These changes allow simulating a local server where `/scripts/` references work from any HTML file in the workspace